### PR TITLE
Add fix to set LSB seconds correctly for RTC

### DIFF
--- a/src/gw_sys/gw_system.c
+++ b/src/gw_sys/gw_system.c
@@ -786,7 +786,7 @@ gw_time_t gw_system_get_time()
 
 	/* Seconds */
 	time.seconds = (gw_ram[gw_head.time_sec_address_msb] * 10) + \
-	gw_ram[gw_head.time_sec_address_msb];
+	gw_ram[gw_head.time_sec_address_lsb];
 
 	//PM
 	if (hour_msb & pm_flag) {
@@ -852,5 +852,5 @@ void gw_system_set_time(gw_time_t time)
 
 	/* Seconds */
 	gw_ram[gw_head.time_sec_address_msb] = time.seconds / 10;
-	gw_ram[gw_head.time_sec_address_msb] = time.seconds % 10;
+	gw_ram[gw_head.time_sec_address_lsb] = time.seconds % 10;
 }


### PR DESCRIPTION
Fix to set the the LSB correctly for seconds from the RTC.

I discovered this when testing the Shuttle Voyage game, as the seconds would not set correctly. This fixes that and I didn't see any issue with the Nintendo Game & Watch games.