### PR TITLE
Fix: call lz4_get_original_size() insted of apparently unexistent lz4_get_file_size()

### DIFF
--- a/src/gw_sys/gw_romloader.c
+++ b/src/gw_sys/gw_romloader.c
@@ -163,7 +163,7 @@ bool gw_romloader_rom2ram()
    else if (memcmp(src, LZ4_MAGIC, 4) == 0)
    {
       printf("ROM LZ4 detected\n");
-      rom_size_compressed_src = lz4_get_file_size(src);
+      rom_size_compressed_src = lz4_get_original_size(src);
 
       rom_size_src = lz4_uncompress(src, dest);
 


### PR DESCRIPTION
I changed to LCD-Game-Emulator git last version under [game-and-watch-retro-go](https://github.com/kbeckmann/game-and-watch-retro-go), I when compiling I get the following error:

```
LCD-Game-Emulator/src/gw_sys/gw_romloader.c: In function 'gw_romloader_rom2ram':
LCD-Game-Emulator/src/gw_sys/gw_romloader.c:160:33: warning: implicit declaration of function 'lz4_get_file_size'; did you mean 'lz4_get_original_size'? [-Wimplicit-function-declaration]
  160 |       rom_size_compressed_src = lz4_get_file_size(src);
      |                                 ^~~~~~~~~~~~~~~~~
      |                                 lz4_get_original_size
[ CC gw ] gw_system.c
[ CC gw ] main_gw.c
[ LD ] gw_retro_go.elf
/home/pi/opt/xpack-arm-none-eabi-gcc-10.2.1-1.1/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: build/gw/gw_romloader.o: in function `gw_romloader_rom2ram':
/home/pi/opt/game-and-watch-retro-go/LCD-Game-Emulator/src/gw_sys/gw_romloader.c:160: undefined reference to `lz4_get_file_size'
```

In this patch I just change the function lz4_get_file_size() to lz4_get_original_size() as the compiler suggest and then compiles and works correctly.
